### PR TITLE
ORADB: Installation using pre-extracted directory structure

### DIFF
--- a/modules/oradb/README.md
+++ b/modules/oradb/README.md
@@ -1,27 +1,27 @@
 Oracle Database Linux puppet module
 =================================================
 
-created by Edwin Biemond   
-[biemond.blogspot.com](http://biemond.blogspot.com)    
-[Github homepage](https://github.com/biemond/puppet)    
+created by Edwin Biemond
+[biemond.blogspot.com](http://biemond.blogspot.com)
+[Github homepage](https://github.com/biemond/puppet)
 
-Should work for RedHat, CentOS, Ubuntu, Debian, Suse SLES or OracleLinux 
+Should work for RedHat, CentOS, Ubuntu, Debian, Suse SLES or OracleLinux
 
-Works with Puppet 2.7 & 3.0 
+Works with Puppet 2.7 & 3.0
 
 Version updates
 ---------------
 
-- 0.8.1 Removed sleep and replaced by waitforcompletion   
-- 0.8.0 Autostart bugfixes and support for oracle 11.2.0.4  database   
-- 0.7.9 Autostart of listener and database with chkconfig / init.d   
-- 0.7.8 Added Suse SLES as Operating System   
-- 0.7.7 RCU support for WebCenter and SOA Suite  
-- 0.7.6 OPatch upgrade made by Ronald Hatcher  
-- 0.7.5 support for Oracle database 12c or 12.1.0.1 plus bug fixes  
-- 0.7.4 puppet 3.0 compatible  
-- 0.7.3 bugfixes plus facts in sync with wls modules   
-- 0.7.2 bugfixes for rcu and database facts 
+- 0.8.1 Removed sleep and replaced by waitforcompletion
+- 0.8.0 Autostart bugfixes and support for oracle 11.2.0.4  database
+- 0.7.9 Autostart of listener and database with chkconfig / init.d
+- 0.7.8 Added Suse SLES as Operating System
+- 0.7.7 RCU support for WebCenter and SOA Suite
+- 0.7.6 OPatch upgrade made by Ronald Hatcher
+- 0.7.5 support for Oracle database 12c or 12.1.0.1 plus bug fixes
+- 0.7.4 puppet 3.0 compatible
+- 0.7.3 bugfixes plus facts in sync with wls modules
+- 0.7.2 bugfixes for rcu and database facts
 
 
 Oracle Database Features
@@ -31,82 +31,82 @@ Oracle Database Features
 - Oracle Database 11.2.0.4 Linux installation
 - Oracle Database 11.2.0.3 Linux installation
 - Oracle Database 11.2.0.1 Linux installation
-- Oracle Database Net configuration   
+- Oracle Database Net configuration
 - Oracle Database Listener
-- OPatch upgrade      
-- Apply OPatch  
-- Create database instances  
-- Stop/Start database instances  
-- Installs RCU repositoy for Oracle SOA Suite / Webcenter ( 11.1.1.6.0 and 11.1.1.7.0 )   
+- OPatch upgrade
+- Apply OPatch
+- Create database instances
+- Stop/Start database instances
+- Installs RCU repositoy for Oracle SOA Suite / Webcenter ( 11.1.1.6.0 and 11.1.1.7.0 )
 
-Some manifests like installdb.pp, opatch.pp or rcusoa.pp supports an alternative mountpoint for the big oracle files.  
-When not provided it uses the files location of the oradb puppet module  
-else you can use $puppetDownloadMntPoint => "/mnt" or "puppet:///modules/xxxx/"  
+Some manifests like installdb.pp, opatch.pp or rcusoa.pp supports an alternative mountpoint for the big oracle files.
+When not provided it uses the files location of the oradb puppet module
+else you can use $puppetDownloadMntPoint => "/mnt" or "puppet:///modules/xxxx/"
 
 Coming in next release
 
 - Oracle Database 11.2.0.1 Linux Client installation
-                                         
+
 Files
 -----
-For 11.2.0.3 Download oracle database linux software from http://support.oracle.com  
-Patch 10404530: 11.2.0.3.0 PATCH SET FOR ORACLE DATABASE SERVER  
-and upload this to the files folder of the oradb puppet module  
+For 11.2.0.3 Download oracle database linux software from http://support.oracle.com
+Patch 10404530: 11.2.0.3.0 PATCH SET FOR ORACLE DATABASE SERVER
+and upload this to the files folder of the oradb puppet module
 
 For 11.2.0.1 Download oracle database linux software from http://otn.oracle.com
 
 For 12.1.0.1 Download oracle database linux software from http://otn.oracle.com
 
-# database files of linux 12.1.0.1 ( otn.oracle.com )  
-1361028723 Jun 27 23:38 linuxamd64_12c_database_1of2.zip  
-1116527103 Jun 27 23:38 linuxamd64_12c_database_2of2.zip  
+# database files of linux 12.1.0.1 ( otn.oracle.com )
+1361028723 Jun 27 23:38 linuxamd64_12c_database_1of2.zip
+1116527103 Jun 27 23:38 linuxamd64_12c_database_2of2.zip
 
-# database files of linux 11.2.0.3 ( support.oracle.com )  
-1358454646 Mar  9 17:31 p10404530_112030_Linux-x86-64_1of7.zip  
-1142195302 Mar  9 17:47 p10404530_112030_Linux-x86-64_2of7.zip  
- 979195792 Mar  9 18:01 p10404530_112030_Linux-x86-64_3of7.zip  
- 659229728 Mar  9 18:11 p10404530_112030_Linux-x86-64_4of7.zip  
- 616473105 Mar  9 18:19 p10404530_112030_Linux-x86-64_5of7.zip  
- 479890040 Mar  9 18:26 p10404530_112030_Linux-x86-64_6of7.zip  
- 113915106 Mar  9 18:28 p10404530_112030_Linux-x86-64_7of7.zip  
+# database files of linux 11.2.0.3 ( support.oracle.com )
+1358454646 Mar  9 17:31 p10404530_112030_Linux-x86-64_1of7.zip
+1142195302 Mar  9 17:47 p10404530_112030_Linux-x86-64_2of7.zip
+ 979195792 Mar  9 18:01 p10404530_112030_Linux-x86-64_3of7.zip
+ 659229728 Mar  9 18:11 p10404530_112030_Linux-x86-64_4of7.zip
+ 616473105 Mar  9 18:19 p10404530_112030_Linux-x86-64_5of7.zip
+ 479890040 Mar  9 18:26 p10404530_112030_Linux-x86-64_6of7.zip
+ 113915106 Mar  9 18:28 p10404530_112030_Linux-x86-64_7of7.zip
 
-# database files of linux 11.2.0.4 ( support.oracle.com )  
-1395582860 Aug 31 16:21 p13390677_112040_Linux-x86-64_1of7.zip  
-1151304589 Aug 31 16:22 p13390677_112040_Linux-x86-64_2of7.zip  
-1205251894 Aug 31 16:22 p13390677_112040_Linux-x86-64_3of7.zip  
- 656026876 Aug 31 16:22 p13390677_112040_Linux-x86-64_4of7.zip  
- 599170344 Aug 31 16:23 p13390677_112040_Linux-x86-64_5of7.zip  
- 488372844 Aug 31 16:23 p13390677_112040_Linux-x86-64_6of7.zip  
- 119521122 Aug 31 16:23 p13390677_112040_Linux-x86-64_7of7.zip  
+# database files of linux 11.2.0.4 ( support.oracle.com )
+1395582860 Aug 31 16:21 p13390677_112040_Linux-x86-64_1of7.zip
+1151304589 Aug 31 16:22 p13390677_112040_Linux-x86-64_2of7.zip
+1205251894 Aug 31 16:22 p13390677_112040_Linux-x86-64_3of7.zip
+ 656026876 Aug 31 16:22 p13390677_112040_Linux-x86-64_4of7.zip
+ 599170344 Aug 31 16:23 p13390677_112040_Linux-x86-64_5of7.zip
+ 488372844 Aug 31 16:23 p13390677_112040_Linux-x86-64_6of7.zip
+ 119521122 Aug 31 16:23 p13390677_112040_Linux-x86-64_7of7.zip
 
-# database files of linux 11.2.0.1 ( otn.oracle.com )  
- 1239269270 Mar 10 17:05 linux.x64_11gR2_database_1of2.zip  
- 1111416131 Mar 10 17:17 linux.x64_11gR2_database_2of2.zip  
+# database files of linux 11.2.0.1 ( otn.oracle.com )
+ 1239269270 Mar 10 17:05 linux.x64_11gR2_database_1of2.zip
+ 1111416131 Mar 10 17:17 linux.x64_11gR2_database_2of2.zip
 
-# opatch database patch for 11.2.0.3    
-  25556377 Mar 10 12:48 p14727310_112030_Linux-x86-64.zip  
+# opatch database patch for 11.2.0.3
+  25556377 Mar 10 12:48 p14727310_112030_Linux-x86-64.zip
 
 # opatch upgrade
   32551984 Jul  6 18:58 p6880880_112000_Linux-x86-64.zip
 
-# database client linux 11.2.0.1 ( otn.oracle.com )  
- 706187979 Mar 10 16:48 linux.x64_11gR2_client.zip  
+# database client linux 11.2.0.1 ( otn.oracle.com )
+ 706187979 Mar 10 16:48 linux.x64_11gR2_client.zip
 
 # rcu linux installer
- 408989041 Mar 17 20:17 ofm_rcu_linux_11.1.1.6.0_disk1_1of1.zip  
- 411498103 Apr  1 21:23 ofm_rcu_linux_11.1.1.7.0_32_disk1_1of1.zip  
+ 408989041 Mar 17 20:17 ofm_rcu_linux_11.1.1.6.0_disk1_1of1.zip
+ 411498103 Apr  1 21:23 ofm_rcu_linux_11.1.1.7.0_32_disk1_1of1.zip
 
 important support node
-[ID 1441282.1] Requirements for Installing Oracle 11gR2 RDBMS on RHEL6 or OL6 64-bit (x86-64)  
+[ID 1441282.1] Requirements for Installing Oracle 11gR2 RDBMS on RHEL6 or OL6 64-bit (x86-64)
 
 
 Oracle Database Facter
 -------------------
-Contains Oracle Facter which displays the following 
+Contains Oracle Facter which displays the following
 - Oracle Software
 - Opatch patches
 
-### Example of the Oracle Database Facts 
+### Example of the Oracle Database Facts
 
     ora_inst_loc_data /oracle/oraInventory
     ora_inst_patches_oracle_product_11.2_db Patches;14727310;
@@ -115,9 +115,9 @@ Contains Oracle Facter which displays the following
 templates.pp
 ------------
 
-The databaseType value should contain only one of these choices.        
-- EE     : Enterprise Edition                                
-- SE     : Standard Edition                                  
+The databaseType value should contain only one of these choices.
+- EE     : Enterprise Edition
+- SE     : Standard Edition
 - SEONE  : Standard Edition One
 
      #$puppetDownloadMntPoint = "puppet:///database/"
@@ -129,10 +129,12 @@ The databaseType value should contain only one of these choices.
             databaseType           => 'SE',
             oracleBase             => '/oracle',
             oracleHome             => '/oracle/product/12.1/db',
+            createUser             => true,
             user                   => 'oracle',
             group                  => 'dba',
             downloadDir            => '/data/install',
-            puppetDownloadMntPoint => $puppetDownloadMntPoint,  
+            zipExtract             => true,
+            puppetDownloadMntPoint => $puppetDownloadMntPoint,
      }
 
 or
@@ -143,10 +145,12 @@ or
             databaseType           => 'SE',
             oracleBase             => '/oracle',
             oracleHome             => '/oracle/product/11.2/db',
+            createUser             => true,
             user                   => 'oracle',
             group                  => 'dba',
             downloadDir            => '/install',
-            puppetDownloadMntPoint => $puppetDownloadMntPoint,  
+            zipExtract             => true,
+            puppetDownloadMntPoint => $puppetDownloadMntPoint,
     }
 
 or
@@ -157,59 +161,63 @@ or
             databaseType           => 'SE',
             oracleBase             => '/oracle',
             oracleHome             => '/oracle/product/11.2/db',
+            createUser             => true,
             user                   => 'oracle',
             group                  => 'dba',
             downloadDir            => '/install',
-            puppetDownloadMntPoint => $puppetDownloadMntPoint,   
+            zipExtract             => true,
+            puppetDownloadMntPoint => $puppetDownloadMntPoint,
      }
 
-or 
+or
 
     oradb::installdb{ '112010_Linux-x86-64':
-            version      => '11.2.0.1', 
+            version      => '11.2.0.1',
             file         => 'linux.x64_11gR2_database',
             databaseType => 'SE',
             oracleBase   => '/oracle',
             oracleHome   => '/oracle/product/11.2/db',
+            createUser   => true,
             user         => 'oracle',
             group        => 'dba',
-            downloadDir  => '/install',  
+            downloadDir  => '/install',
+            zipExtract   => true,
      }
 
 
 other
-  
+
 	    oradb::opatchupgrade{'112000_opatch_upgrade':
-	      oracleHome             => '/oracle/product/11.2/db' ,
-	      patchFile              => 'p6880880_112000_Linux-x86-64.zip', 
+	      oracleHome             => '/oracle/product/11.2/db',
+	      patchFile              => 'p6880880_112000_Linux-x86-64.zip',
 	      csiNumber              => '11111',
 	      supportId              => 'biemond@gmail.com',
 	      opversion              => '11.2.0.3.4',
 	      user                   => 'oracle',
 	      group                  => 'dba',
 	      downloadDir            => '/install',
-	      puppetDownloadMntPoint => $puppetDownloadMntPoint,    
+	      puppetDownloadMntPoint => $puppetDownloadMntPoint,
 	      require                =>  Oradb::Installdb['112030_Linux-x86-64'],
 	    }
-	
-	
+
+
 	   # for this example OPatch 14727310
 	   # the OPatch utility must be upgraded ( patch 6880880, see above)
 	   oradb::opatch{'14727310_db_patch':
-	     oracleProductHome      => '/oracle/product/11.2/db' ,
-	     patchId                => '14727310', 
-	     patchFile              => 'p14727310_112030_Linux-x86-64.zip',  
+	     oracleProductHome      => '/oracle/product/11.2/db',
+	     patchId                => '14727310',
+	     patchFile              => 'p14727310_112030_Linux-x86-64.zip',
 	     user                   => 'oracle',
 	     group                  => 'dba',
 	     downloadDir            => '/install',
-	     ocmrf                  => true,   
+	     ocmrf                  => true,
 	     require                => Oradb::Opatchupgrade['112000_opatch_upgrade'],
-	     puppetDownloadMntPoint => $puppetDownloadMntPoint, 
+	     puppetDownloadMntPoint => $puppetDownloadMntPoint,
 	   }
 
        oradb::net{ 'config net8':
             oracleHome   => '/oracle/product/11.2/db',
-            version      => '11.2' or "12.1",   
+            version      => '11.2' or "12.1",
             user         => 'oracle',
             group        => 'dba',
             downloadDir  => '/install',
@@ -221,23 +229,23 @@ other
             oracleHome   => '/oracle/product/11.2/db',
             user         => 'oracle',
             group        => 'dba',
-            action       => 'start',  
+            action       => 'start',
             require      => Oradb::Net['config net8'],
        }
-  
+
        oradb::listener{'start listener':
             oracleBase   => '/oracle',
             oracleHome   => '/oracle/product/11.2/db',
             user         => 'oracle',
             group        => 'dba',
-            action       => 'start',  
+            action       => 'start',
             require      => Oradb::Listener['stop listener'],
        }
 
-       oradb::database{ 'testDb_Create': 
+       oradb::database{ 'testDb_Create':
                       oracleBase              => '/oracle',
                       oracleHome              => '/oracle/product/11.2/db',
-                      version                 => '11.2' or "12.1", 
+                      version                 => '11.2' or "12.1",
                       user                    => 'oracle',
                       group                   => 'dba',
                       downloadDir             => '/install',
@@ -254,11 +262,11 @@ other
                       sampleSchema            => 'TRUE',
                       memoryPercentage        => "40",
                       memoryTotal             => "800",
-                      databaseType            => "MULTIPURPOSE",                         
+                      databaseType            => "MULTIPURPOSE",
                       require                 => Oradb::Listener['start listener'],
      }
-  
-    oradb::dbactions{ 'stop testDb': 
+
+    oradb::dbactions{ 'stop testDb':
                      oracleHome              => '/oracle/product/11.2/db',
                      user                    => 'oracle',
                      group                   => 'dba',
@@ -266,8 +274,8 @@ other
                      dbName                  => 'test',
                      require                 => Oradb::Database['testDb'],
     }
-  
-    oradb::dbactions{ 'start testDb': 
+
+    oradb::dbactions{ 'start testDb':
                      oracleHome              => '/oracle/product/11.2/db',
                      user                    => 'oracle',
                      group                   => 'dba',
@@ -276,7 +284,7 @@ other
                      require                 => Oradb::Dbactions['stop testDb'],
     }
 
-	oradb::autostartdatabase{ 'autostart oracle': 
+	oradb::autostartdatabase{ 'autostart oracle':
 	                   oracleHome              => '/oracle/product/12.1/db',
 	                   user                    => 'oracle',
 	                   dbName                  => 'test',
@@ -285,7 +293,7 @@ other
 
 
 
-    oradb::database{ 'testDb_Delete': 
+    oradb::database{ 'testDb_Delete':
                       oracleBase              => '/oracle',
                       oracleHome              => '/oracle/product/11.2/db',
                       user                    => 'oracle',
@@ -298,50 +306,47 @@ other
     }
 
 	  case $operatingsystem {
-	    CentOS, RedHat, OracleLinux, Ubuntu, Debian: { 
+	    CentOS, RedHat, OracleLinux, Ubuntu, Debian: {
 	      $mtimeParam = "1"
 	    }
-	    Solaris: { 
+	    Solaris: {
 	      $mtimeParam = "+1"
 	    }
 	  }
-	
-	
+
+
 	  case $operatingsystem {
-	    CentOS, RedHat, OracleLinux, Ubuntu, Debian, Solaris: { 
-	
-			  cron { 'oracle_db_opatch' :
+	    CentOS, RedHat, OracleLinux, Ubuntu, Debian, Solaris: {
+			  cron { 'oracle_db_opatch':
 			    command => "find /oracle/product/12.1/db/cfgtoollogs/opatch -name 'opatch*.log' -mtime ${mtimeParam} -exec rm {} \\; >> /tmp/opatch_db_purge.log 2>&1",
 			    user    => oracle,
 			    hour    => 06,
 			    minute  => 34,
 			  }
-			 
-			  cron { 'oracle_db_lsinv' :
+
+			  cron { 'oracle_db_lsinv':
 			    command => "find /oracle/product/12.1/db/cfgtoollogs/opatch/lsinv -name 'lsinventory*.txt' -mtime ${mtimeParam} -exec rm {} \\; >> /tmp/opatch_lsinv_db_purge.log 2>&1",
 			    user    => oracle,
 			    hour    => 06,
 			    minute  => 32,
 			  }
-	
-	
 	    }
 	  }
 
-  
+
 
 Oracle SOA Suite Repository Creation Utility (RCU)
 
     oradb::rcu{     'DEV_PS6':
                      rcuFile          => 'ofm_rcu_linux_11.1.1.7.0_32_disk1_1of1.zip',
                      product          => 'soasuite',
-                     version          => '11.1.1.7',  
+                     version          => '11.1.1.7',
                      oracleHome       => '/oracle/product/11.2/db',
                      user             => 'oracle',
                      group            => 'dba',
                      downloadDir      => '/install',
                      action           => 'create',
-                     dbServer         => 'dbagent1.alfa.local:1521',  
+                     dbServer         => 'dbagent1.alfa.local:1521',
                      dbService        => 'test.oracle.com',
                      sysPassword      => 'Welcome01',
                      schemaPrefix     => 'DEV',
@@ -351,13 +356,13 @@ Oracle SOA Suite Repository Creation Utility (RCU)
     oradb::rcu{     'DEV2_PS6':
                      rcuFile          => 'ofm_rcu_linux_11.1.1.7.0_32_disk1_1of1.zip',
                      product          => 'webcenter',
-                     version          => '11.1.1.7',  
+                     version          => '11.1.1.7',
                      oracleHome       => '/oracle/product/11.2/db',
                      user             => 'oracle',
                      group            => 'dba',
                      downloadDir      => '/install',
                      action           => 'create',
-                     dbServer         => 'dbagent1.alfa.local:1521',  
+                     dbServer         => 'dbagent1.alfa.local:1521',
                      dbService        => 'test.oracle.com',
                      sysPassword      => 'Welcome01',
                      schemaPrefix     => 'DEV',
@@ -368,13 +373,13 @@ Oracle SOA Suite Repository Creation Utility (RCU)
     oradb::rcu{     'Delete_DEV3_PS5':
                      rcuFile          => 'ofm_rcu_linux_11.1.1.6.0_disk1_1of1.zip',
                      product          => 'soasuite',
-                     version          => '11.1.1.6',  
+                     version          => '11.1.1.6',
                      oracleHome       => '/oracle/product/11.2/db',
                      user             => 'oracle',
                      group            => 'dba',
                      downloadDir      => '/install',
                      action           => 'delete',
-                     dbServer         => 'dbagent1.alfa.local:1521',  
+                     dbServer         => 'dbagent1.alfa.local:1521',
                      dbService        => 'test.oracle.com',
                      sysPassword      => 'Welcome01',
                      schemaPrefix     => 'DEV3',
@@ -388,15 +393,14 @@ Oracle SOA Suite Repository Creation Utility (RCU)
 site.pp
 -------
 
-install the following module to set the database kernel parameters  
-*puppet module install fiddyspence-sysctl*  
+install the following module to set the database kernel parameters
+*puppet module install fiddyspence-sysctl*
 
-install the following module to set the database user limits parameters  
+install the following module to set the database user limits parameters
 *puppet module install erwbgy-limits*
 
-     
+
      node database {
-     
       sysctl { 'kernel.msgmnb':                 ensure => 'present', permanent => 'yes', value => '65536',}
 	  sysctl { 'kernel.msgmax':                 ensure => 'present', permanent => 'yes', value => '65536',}
 	  sysctl { 'kernel.shmmax':                 ensure => 'present', permanent => 'yes', value => '2588483584',}
@@ -415,7 +419,7 @@ install the following module to set the database user limits parameters
 	  sysctl { 'net.core.wmem_default':         ensure => 'present', permanent => 'yes', value => '262144',}
 	  sysctl { 'net.core.wmem_max':             ensure => 'present', permanent => 'yes', value => '1048576',}
 
-     
+
        class { 'limits':
          config => {
                     '*'       => { 'nofile'  => { soft => '2048'   , hard => '8192',   },},
@@ -425,19 +429,18 @@ install the following module to set the database user limits parameters
                     },
          use_hiera => false,
        }
-     
-     
+
+
        $install = [ 'binutils.x86_64', 'compat-libstdc++-33.x86_64', 'glibc.x86_64','ksh.x86_64','libaio.x86_64',
                     'libgcc.x86_64', 'libstdc++.x86_64', 'make.x86_64','compat-libcap1.x86_64', 'gcc.x86_64',
                     'gcc-c++.x86_64','glibc-devel.x86_64','libaio-devel.x86_64','libstdc++-devel.x86_64',
                     'sysstat.x86_64','unixODBC-devel','glibc.i686']
-               
+
        package { $install:
          ensure  => present,
        }
-     
+
      }
-     
+
      node 'dbagent1.alfa.local' inherits database {
      }
-     

--- a/modules/oradb/manifests/installdb.pp
+++ b/modules/oradb/manifests/installdb.pp
@@ -15,7 +15,8 @@
 #            user         => 'oracle',
 #            group        => 'dba',
 #            downloadDir  => '/install',
-#         }
+#            zipExtract   => true,
+#    }
 #
 #    oradb::installdb{ '112010_Linux-x86-64':
 #            version      => '11.2.0.1',
@@ -27,7 +28,8 @@
 #            user         => 'oracle',
 #            group        => 'dba',
 #            downloadDir  => '/install',
-#         }
+#            zipExtract   => true,
+#    }
 #
 #
 #
@@ -40,6 +42,7 @@ define oradb::installdb( $version                 = undef,
                          $user                    = 'oracle',
                          $group                   = 'dba',
                          $downloadDir             = '/install',
+                         $zipExtract              = true,
                          $puppetDownloadMntPoint  = undef,
 )
 
@@ -125,113 +128,116 @@ define oradb::installdb( $version                 = undef,
       }
     }
 
-    if $version == '12.1.0.1' {
-      # db file 1 installer zip
-      file { "${path}/${file}_1of2.zip":
-        source        => "${mountPoint}/${file}_1of2.zip",
-        require       => File[$path],
+    if ( $zipExtract ) {
+      # In $downloadDir, will Puppet extract the ZIP files or is this a pre-extracted directory structure.
+      if $version == '12.1.0.1' {
+        # db file 1 installer zip
+        file { "${path}/${file}_1of2.zip":
+          source      => "${mountPoint}/${file}_1of2.zip",
+          require     => File[$path],
+        }
+        exec { "extract ${path}/${file}_1of2.zip":
+          command     => "unzip -o ${path}/${file}_1of2.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_1of2.zip"],
+          creates     => "${path}/${file}/database/install/addLangs.sh",
+        }
+        # db file 2 installer zip
+        file { "${path}/${file}_2of2.zip":
+          source      => "${mountPoint}/${file}_2of2.zip",
+          require     => File["${path}/${file}_1of2.zip"],
+        }
+        exec { "extract ${path}/${file}_2of2.zip":
+          command     => "unzip -o ${path}/${file}_2of2.zip -d ${path}/${file}",
+          require     => [ File["${path}/${file}_2of2.zip"], Exec["extract ${path}/${file}_1of2.zip"], ],
+          creates     => "${path}/${file}/database/stage/Components/oracle.rdbms/12.1.0.1.0/1/DataFiles/filegroup19.6.1.jar",
+        }
       }
-      exec { "extract ${path}/${file}_1of2.zip":
-        command       => "unzip -o ${path}/${file}_1of2.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_1of2.zip"],
-        creates       => "${path}/${file}/database/install/addLangs.sh",
-      }
-      # db file 2 installer zip
-      file { "${path}/${file}_2of2.zip":
-        source        => "${mountPoint}/${file}_2of2.zip",
-        require       => File["${path}/${file}_1of2.zip"],
-      }
-      exec { "extract ${path}/${file}_2of2.zip":
-        command       => "unzip -o ${path}/${file}_2of2.zip -d ${path}/${file}",
-        require       => [ File["${path}/${file}_2of2.zip"], Exec["extract ${path}/${file}_1of2.zip"], ],
-        creates       => "${path}/${file}/database/stage/Components/oracle.rdbms/12.1.0.1.0/1/DataFiles/filegroup19.6.1.jar",
-      }
-    }
 
-    if $version == '11.2.0.1' {
-      # db file 1 installer zip
-      file { "${path}/${file}_1of2.zip":
-        source        => "${mountPoint}/${file}_1of2.zip",
-        require       => File[$path],
+      if $version == '11.2.0.1' {
+        # db file 1 installer zip
+        file { "${path}/${file}_1of2.zip":
+          source      => "${mountPoint}/${file}_1of2.zip",
+          require     => File[$path],
+        }
+        exec { "extract ${path}/${file}_1of2.zip":
+          command     => "unzip -o ${path}/${file}_1of2.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_1of2.zip"],
+        }
+        # db file 2 installer zip
+        file { "${path}/${file}_2of2.zip":
+          source      => "${mountPoint}/${file}_2of2.zip",
+          require     => File["${path}/${file}_1of2.zip"],
+        }
+        exec { "extract ${path}/${file}_2of2.zip":
+          command     => "unzip -o ${path}/${file}_2of2.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_2of2.zip"],
+        }
       }
-      exec { "extract ${path}/${file}_1of2.zip":
-        command       => "unzip -o ${path}/${file}_1of2.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_1of2.zip"],
-      }
-      # db file 2 installer zip
-      file { "${path}/${file}_2of2.zip":
-        source        => "${mountPoint}/${file}_2of2.zip",
-        require       => File["${path}/${file}_1of2.zip"],
-      }
-      exec { "extract ${path}/${file}_2of2.zip":
-        command       => "unzip -o ${path}/${file}_2of2.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_2of2.zip"],
-      }
-    }
 
-    if ( $version == '11.2.0.3' or $version == '11.2.0.4' ) {
-      # db file 1 installer zip
-      file { "${path}/${file}_1of7.zip":
-        source        => "${mountPoint}/${file}_1of7.zip",
-        require       => File[$path],
-      }
-      exec { "extract ${path}/${file}_1of7.zip":
-        command       => "unzip -o ${path}/${file}_1of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_1of7.zip"],
-      }
-      # db file 2 installer zip
-      file { "${path}/${file}_2of7.zip":
-        source        => "${mountPoint}/${file}_2of7.zip",
-        require       => File["${path}/${file}_1of7.zip"],
-      }
-      exec { "extract ${path}/${file}_2of7.zip":
-        command       => "unzip -o ${path}/${file}_2of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_2of7.zip"],
-      }
-      # db file 3 installer zip
-      file { "${path}/${file}_3of7.zip":
-        source        => "${mountPoint}/${file}_3of7.zip",
-        require       => File["${path}/${file}_2of7.zip"],
-      }
-      exec { "extract ${path}/${file}_3of7.zip":
-        command       => "unzip -o ${path}/${file}_3of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_3of7.zip"],
-      }
-      # db file 4 installer zip
-      file { "${path}/${file}_4of7.zip":
-        source        => "${mountPoint}/${file}_4of7.zip",
-        require       => File["${path}/${file}_3of7.zip"],
-      }
-      exec { "extract ${path}/${file}_4of7.zip":
-        command       => "unzip -o ${path}/${file}_4of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_4of7.zip"],
-      }
-      # db file 5 installer zip
-      file { "${path}/${file}_5of7.zip":
-        source        => "${mountPoint}/${file}_5of7.zip",
-        require       => File["${path}/${file}_4of7.zip"],
-      }
-      exec { "extract ${path}/${file}_5of7.zip":
-        command       => "unzip -o ${path}/${file}_5of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_5of7.zip"],
-      }
-      # db file 6 installer zip
-      file { "${path}/${file}_6of7.zip":
-        source        => "${mountPoint}/${file}_6of7.zip",
-        require       => File["${path}/${file}_5of7.zip"],
-      }
-      exec { "extract ${path}/${file}_6of7.zip":
-        command       => "unzip -o ${path}/${file}_6of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_6of7.zip"],
-      }
-      # db file 7 installer zip
-      file { "${path}/${file}_7of7.zip":
-        source        => "${mountPoint}/${file}_7of7.zip",
-        require       => File["${path}/${file}_6of7.zip"],
-      }
-      exec { "extract ${path}/${file}_7of7.zip":
-        command       => "unzip -o ${path}/${file}_7of7.zip -d ${path}/${file}",
-        require       => File["${path}/${file}_7of7.zip"],
+      if ( $version == '11.2.0.3' or $version == '11.2.0.4' ) {
+        # db file 1 installer zip
+        file { "${path}/${file}_1of7.zip":
+          source      => "${mountPoint}/${file}_1of7.zip",
+          require     => File[$path],
+        }
+        exec { "extract ${path}/${file}_1of7.zip":
+          command     => "unzip -o ${path}/${file}_1of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_1of7.zip"],
+        }
+        # db file 2 installer zip
+        file { "${path}/${file}_2of7.zip":
+          source      => "${mountPoint}/${file}_2of7.zip",
+          require     => File["${path}/${file}_1of7.zip"],
+        }
+        exec { "extract ${path}/${file}_2of7.zip":
+          command     => "unzip -o ${path}/${file}_2of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_2of7.zip"],
+        }
+        # db file 3 installer zip
+        file { "${path}/${file}_3of7.zip":
+          source      => "${mountPoint}/${file}_3of7.zip",
+          require     => File["${path}/${file}_2of7.zip"],
+        }
+        exec { "extract ${path}/${file}_3of7.zip":
+          command     => "unzip -o ${path}/${file}_3of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_3of7.zip"],
+        }
+        # db file 4 installer zip
+        file { "${path}/${file}_4of7.zip":
+          source      => "${mountPoint}/${file}_4of7.zip",
+          require     => File["${path}/${file}_3of7.zip"],
+        }
+        exec { "extract ${path}/${file}_4of7.zip":
+          command     => "unzip -o ${path}/${file}_4of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_4of7.zip"],
+        }
+        # db file 5 installer zip
+        file { "${path}/${file}_5of7.zip":
+          source      => "${mountPoint}/${file}_5of7.zip",
+          require     => File["${path}/${file}_4of7.zip"],
+        }
+        exec { "extract ${path}/${file}_5of7.zip":
+          command     => "unzip -o ${path}/${file}_5of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_5of7.zip"],
+        }
+        # db file 6 installer zip
+        file { "${path}/${file}_6of7.zip":
+          source      => "${mountPoint}/${file}_6of7.zip",
+          require     => File["${path}/${file}_5of7.zip"],
+        }
+        exec { "extract ${path}/${file}_6of7.zip":
+          command     => "unzip -o ${path}/${file}_6of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_6of7.zip"],
+        }
+        # db file 7 installer zip
+        file { "${path}/${file}_7of7.zip":
+          source      => "${mountPoint}/${file}_7of7.zip",
+          require     => File["${path}/${file}_6of7.zip"],
+        }
+        exec { "extract ${path}/${file}_7of7.zip":
+          command     => "unzip -o ${path}/${file}_7of7.zip -d ${path}/${file}",
+          require     => File["${path}/${file}_7of7.zip"],
+        }
       }
     }
 
@@ -260,26 +266,53 @@ define oradb::installdb( $version                 = undef,
     }
 
     if $version == '12.1.0.1' {
-      exec { "install oracle database ${title}":
-        command       => "/bin/sh -c 'unset DISPLAY;${path}/${file}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
-        require       => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"],Exec["extract ${path}/${file}_2of2.zip"]],
-        creates       => $oracleHome,
+      if ( $zipExtract ) {
+        # In $downloadDir, will Puppet extract the ZIP files or is this a pre-extracted directory structure.
+        exec { "install oracle database ${title}":
+          command     => "/bin/sh -c 'unset DISPLAY;${path}/${file}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
+          require     => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"],Exec["extract ${path}/${file}_2of2.zip"]],
+          creates     => $oracleHome,
+        }
+      } else {
+        exec { "install oracle database ${title}":
+          command     => "/bin/sh -c 'unset DISPLAY;${path}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
+          require     => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"]],
+          creates     => $oracleHome,
+        }
       }
     }
 
     if ( $version == '11.2.0.3' or $version == '11.2.0.4' ) {
-      exec { "install oracle database ${title}":
-        command       => "/bin/sh -c 'unset DISPLAY;${path}/${file}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
-        require       => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"],Exec["extract ${path}/${file}_7of7.zip"]],
-        creates       => $oracleHome,
+      if ( $zipExtract ) {
+        # In $downloadDir, will Puppet extract the ZIP files or is this a pre-extracted directory structure.
+        exec { "install oracle database ${title}":
+          command     => "/bin/sh -c 'unset DISPLAY;${path}/${file}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
+          require     => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"],Exec["extract ${path}/${file}_7of7.zip"]],
+          creates     => $oracleHome,
+        }
+      } else {
+        exec { "install oracle database ${title}":
+          command     => "/bin/sh -c 'unset DISPLAY;${path}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
+          require     => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"]],
+          creates     => $oracleHome,
+        }
       }
     }
 
     if $version == '11.2.0.1' {
-      exec { "install oracle database ${title}":
-        command       => "/bin/sh -c 'unset DISPLAY;${path}/${file}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
-        require       => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"],Exec["extract ${path}/${file}_2of2.zip"]],
-        creates       => $oracleHome,
+      if ( $zipExtract ) {
+        # In $downloadDir, will Puppet extract the ZIP files or is this a pre-extracted directory structure.
+        exec { "install oracle database ${title}":
+          command     => "/bin/sh -c 'unset DISPLAY;${path}/${file}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
+          require     => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"],Exec["extract ${path}/${file}_2of2.zip"]],
+          creates     => $oracleHome,
+        }
+      } else {
+        exec { "install oracle database ${title}":
+          command     => "/bin/sh -c 'unset DISPLAY;${path}/database/runInstaller -silent -waitforcompletion -responseFile ${path}/db_install_${version}.rsp'",
+          require     => [File ["${oraInstPath}/oraInst.loc"],File["${path}/db_install_${version}.rsp"]],
+          creates     => $oracleHome,
+        }
       }
     }
 


### PR DESCRIPTION
When the Oracle DB ZIP files are stored in a network location, such as NFS, it may be advantageous for Puppet to use a pre-extracted directory structure rather than unzip the files every time. This removes unnecessary writes to storage and dramatically decreases the overall database installation time.

How to use this:
Set the new boolean $zipExtract to false. This tells Puppet that it will use a pre-extracted directory structure rather than ZIP files. The default is true, use ZIP files.
Example:    zipExtract => false,

As Puppet no longer transfers or uses any ZIP files, defining $puppetDownloadMntPoint isn't necessary.
Example:    puppetDownloadMntPoint => undef,

Set $downloadDir to the directory containing the pre-extracted directory structure. 
Example:    downloadDir => '/nfs/oracle/installer/11.2.0.3',
