### PR TITLE
Added a userBaseDir parameter to oradb::installdb.pp

### DIFF
--- a/modules/oradb/manifests/installdb.pp
+++ b/modules/oradb/manifests/installdb.pp
@@ -26,6 +26,7 @@
 #            oracleHome   => '/oracle/product/11.2/db',
 #            createUser   => 'true',
 #            user         => 'oracle',
+#            userBaseDir  => '/localhome',
 #            group        => 'dba',
 #            downloadDir  => '/install',
 #            zipExtract   => true,
@@ -39,8 +40,8 @@ define oradb::installdb( $version                 = undef,
                          $oracleBase              = undef,
                          $oracleHome              = undef,
                          $createUser              = true,
-                         $homeBaseDir             = '/home',
                          $user                    = 'oracle',
+                         $userBaseDir             = '/home',
                          $group                   = 'dba',
                          $downloadDir             = '/install',
                          $zipExtract              = true,
@@ -109,7 +110,7 @@ define oradb::installdb( $version                 = undef,
           groups      => $group,
           shell       => '/bin/bash',
           password    => '$1$DSJ51vh6$4XzzwyIOk6Bi/54kglGk3.',
-          home        => "${homeBaseDir}/${user}",
+          home        => "${userBaseDir}/${user}",
           comment     => "This user ${user} was created by Puppet",
           require     => Group[$group],
           managehome  => true,
@@ -336,8 +337,8 @@ define oradb::installdb( $version                 = undef,
       }
     }
 
-    if ! defined(File["${homeBaseDir}/${user}/.bash_profile"]) {
-      file { "${homeBaseDir}/${user}/.bash_profile":
+    if ! defined(File["${userBaseDir}/${user}/.bash_profile"]) {
+      file { "${userBaseDir}/${user}/.bash_profile":
         ensure        => present,
         content       => template("oradb/bash_profile.erb"),
       }


### PR DESCRIPTION
Hi,

We have NIS users and local users. By local convention, the NIS user home directories are in /home and local user home directories are in /localhome.

We would like to use the oradb module, but its assumption that the oracle user account is in /home/${user} causes problems because in our case, a global NIS oracle user already exists. Clearly this shouldn't really be the case, but it would be difficult to change that now.

So I propose a simple change to provide a user base directory parameter to installdb.pp which defaults to /home.

Thanks,

Simon.
