### PR TITLE
Added the ability to turn off the notify in init.pp

### DIFF
--- a/modules/oradb/manifests/init.pp
+++ b/modules/oradb/manifests/init.pp
@@ -1,7 +1,9 @@
 # == Class: oradb
 #
-class oradb {
+class oradb ($shout = true) {
 
-  notify {"oradb init.pp":}
+  if $::oradb::shout {
+    notify {"oradb init.pp":}  
+  }
 
 }


### PR DESCRIPTION
Hi,

One more minor change... The notify in oradb init.pp was causing our puppet console to report a change in every single report, even though it wasn't changing anything. I've added a switch to turn it off, if desired.

I was going to remove it, but thought you might have a reason for keeping it there, so default behaviour is retained. If you don't need the notify for anything I'd suggest removing it for this reason.

BTW, the module works really well, and the folks here are very impressed :-)

Thanks for sharing!

Simon.
