### PR TITLE
Enable additional java parameters for wls install

### DIFF
--- a/modules/wls/manifests/installwls.pp
+++ b/modules/wls/manifests/installwls.pp
@@ -39,6 +39,7 @@ define wls::installwls( $version     = undef,
                         $group       = 'dba',
                         $downloadDir = '/install',
                         $remoteFile  = true,
+                        $javaParameters = '',
                         $puppetDownloadMntPoint  = undef,
                       ) {
 
@@ -62,7 +63,7 @@ define wls::installwls( $version     = undef,
 
         $oraInventory    = "${oracleHome}/oraInventory"
         $oraInstPath     = "/etc"
-        $java_statement  = "java"
+        $java_statement  = "java ${javaParameters}"
 
         Exec { path      => $execPath,
                user      => $user,
@@ -85,7 +86,7 @@ define wls::installwls( $version     = undef,
 
         $oraInventory    = "${oracleHome}/oraInventory"
         $oraInstPath     = "/var/opt"
-        $java_statement  = "java -d64"
+        $java_statement  = "java -d64 ${javaParameters}"
 
         Exec { path      => $execPath,
                user      => $user,


### PR DESCRIPTION
When using wls module with Docker, the installer
complain that there's not enough disk space. According
http://docs.oracle.com/cd/E24329_01/doc.1211/e26593/issues.htm#BCFIHGCJ
this check can be circumvented with -Dspace.detection=false.
