### PR TITLE
Update database.pp: Remove output of plain-text passwords to screen and puppet console

### DIFF
--- a/modules/oradb/manifests/database.pp
+++ b/modules/oradb/manifests/database.pp
@@ -107,12 +107,14 @@ define oradb::database(
 
   if ! defined(File["${downloadDir}/database_${sanitized_title}.rsp"]) {
     file { "${downloadDir}/database_${sanitized_title}.rsp":
-      ensure  => present,
-      content => template("oradb/dbca_${version}.rsp.erb"),
-      mode    => '0775',
-      owner   => $user,
-      group   => $group,
-      before  => Exec["oracle database ${title}"],
+      ensure    => present,
+      content   => template("oradb/dbca_${version}.rsp.erb"),
+      mode      => '0775',
+      owner     => $user,
+      group     => $group,
+      before    => Exec["oracle database ${title}"],
+      replace   => false,
+      show_diff => false,
     }
   }
 


### PR DESCRIPTION
First of all - great module, very useful - thank you!

We are using puppet enterprise in an environment where passwords are not generally known by all team members. When running the puppet agent to install oracle, the database.pp causes the system passwords to be output in plain-text to the puppet console. In our environment this discloses information to people who do not need to know the passwords but do need to view server status and information on the puppet console.
The most important part of this update is the "show_diff" setting which prevents the console output.
For 'replace=>false': We have later on added code to copy /dev/null over the response file so that it is not left on the server holding the plain-text passwords. I'm not sure if this was the best fix but we needed something that didn't cause the file to be recreated on the next puppet run. Out change for this is outside the scope of oradb so I'm not sure the best file to change in oradb

Best Regards
Sarah